### PR TITLE
Fix summary page description for offline data

### DIFF
--- a/src/edu/lternet/pasta/portal/MapBrowseServlet.java
+++ b/src/edu/lternet/pasta/portal/MapBrowseServlet.java
@@ -918,7 +918,7 @@ public class MapBrowseServlet extends DataPortalServlet {
 				}					
 				if (hasOffline) {
 					String offlineMsg = 
-							"Offline data: the metadata describes one or more data entities that have not been made available to this repository.";
+							"Offline data: The metadata describes one or more data entities stored offline.";
 					data += String.format("<li>%s</li>\n", offlineMsg);
 				}
 


### PR DESCRIPTION
The existing description is misleading since the offline data could be stored on a disk in our possession (e.g. the large data use case).